### PR TITLE
Deferred building

### DIFF
--- a/lib/paggio/css.rb
+++ b/lib/paggio/css.rb
@@ -38,7 +38,7 @@ class CSS < BasicObject
 
   attr_reader :rules, :media, :fonts, :animations
 
-  def initialize(&block)
+  def initialize(defer: false, &block)
     ::Kernel.raise ::ArgumentError, 'no block given' unless block
 
     @selector   = []
@@ -46,12 +46,19 @@ class CSS < BasicObject
     @rules      = []
     @fonts      = []
     @animations = []
+    
+    @block      = block
 
-    if block.arity == 0
-      instance_exec(&block)
+    build! unless defer
+  end
+
+  def build!(force_call: false)
+    if !force_call && @block.arity == 0
+      instance_exec(&@block)
     else
-      block.call(self)
+      @block.call(self)
     end
+    @block = nil
   end
 
   def rule(*names, &block)

--- a/lib/paggio/css/definition.rb
+++ b/lib/paggio/css/definition.rb
@@ -39,7 +39,7 @@ class Definition < BasicObject
     "url(#{value.to_s.inspect})"
   end
 
-  %w[url blur brightness rotate contrast grayscale invert opacity saturate sepia].each {|name|
+  %w[blur brightness rotate contrast grayscale invert opacity saturate sepia].each {|name|
     define_method name do |value|
       "#{name}(#{value})"
     end

--- a/lib/paggio/html.rb
+++ b/lib/paggio/html.rb
@@ -16,22 +16,29 @@ class Paggio
 class HTML < BasicObject
   attr_reader :version
 
-  def initialize(version = 5, &block)
+  def initialize(version = 5, defer: false, &block)
     ::Kernel.raise ::ArgumentError, 'no block given' unless block
 
     @version = version
     @roots   = []
     @current = nil
 
-    if block.arity == 0
-      instance_exec(&block)
-    else
-      block.call(self)
-    end
+    @block = block
+
+    build! unless defer
   end
 
   def <<(what)
     (@current || @roots) << what
+  end
+
+  def build!(force_call: false)
+    if !force_call && @block.arity == 0
+      instance_exec(&@block)
+    else
+      @block.call(self)
+    end
+    @block = nil
   end
 
   def root!

--- a/lib/paggio/html.rb
+++ b/lib/paggio/html.rb
@@ -99,6 +99,9 @@ class HTML < BasicObject
     element
   end
 
+  # Support for custom elements
+  alias e method_missing
+
   def inspect
     if @roots.empty?
       "#<HTML(#@version)>"

--- a/lib/paggio/html.rb
+++ b/lib/paggio/html.rb
@@ -71,6 +71,11 @@ class HTML < BasicObject
     @roots.each(&block)
   end
 
+  def text(*fragments, &block)
+    fragments << yield if block
+    fragments.each { |fragment| self << fragment }
+  end
+
   def method_missing(name, *args, &block)
     if name.to_s.end_with? ?!
       return super

--- a/lib/paggio/html/element.rb
+++ b/lib/paggio/html/element.rb
@@ -31,7 +31,7 @@ class Element < BasicObject
 
     const = name.capitalize
 
-    if const_defined?(const)
+    if !const.to_s.include?('-') && const_defined?(const)
       const_get(const).new(owner, name, attributes)
     else
       super

--- a/spec/html_spec.rb
+++ b/spec/html_spec.rb
@@ -150,4 +150,14 @@ describe Paggio::HTML do
 
     expect(html.to_s).to eq("<i class=\"illegal icon-legal\">\n</i>\n")
   end
+
+  it 'allows for defered build' do
+    html = Paggio::HTML.new(defer: true) do
+      div
+    end
+    expect(html.roots!.length).to eq(0)
+
+    html.build!
+    expect(html.roots!.length).to eq(1)
+  end
 end

--- a/spec/html_spec.rb
+++ b/spec/html_spec.rb
@@ -168,4 +168,18 @@ describe Paggio::HTML do
 
     expect(html.to_s).to eq("<custom-element id=\"test\" class=\"test\">\n</custom-element>\n")
   end
+
+  it 'supports text nodes' do
+    html = Paggio.html! do
+      div {
+        text "test"
+        text { "test" }
+        text "test"
+        div
+        text "test"
+      }
+    end
+
+    expect(html.to_s).to eq("<div>\n\ttest\n\ttest\n\ttest\n\t<div>\n\t</div>\n\ttest\n</div>\n")
+  end
 end

--- a/spec/html_spec.rb
+++ b/spec/html_spec.rb
@@ -160,4 +160,12 @@ describe Paggio::HTML do
     html.build!
     expect(html.roots!.length).to eq(1)
   end
+
+  it 'allows for custom elements' do
+    html = Paggio.html! do
+      e('custom-element').test.test!
+    end
+
+    expect(html.to_s).to eq("<custom-element id=\"test\" class=\"test\">\n</custom-element>\n")
+  end
 end


### PR DESCRIPTION
With some recent changes to opal-browser I needed to access the builder object before build has taken place. This simple commit implements this in a non-invasive way.